### PR TITLE
Group functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.10.1
--e git+https://github.com/martijnvermaat/flask-sqlalchemy.git@record-ops-only-for-signalling-sessions#egg=Flask-SQLAlchemy
+#-e git+https://github.com/martijnvermaat/flask-sqlalchemy.git@record-ops-only-for-signalling-sessions#egg=Flask-SQLAlchemy
 PyVCF==0.6.7
 SQLAlchemy==0.9.3
 celery==3.1.9

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -151,3 +151,8 @@ class AnnotationData(DataSet):
     class exome_annotation:
         original_data_source = DataSourceData.exome_variation
         annotated_data_source = DataSourceData.empty_variation
+
+        # fixture doesn't take PickleType! So this will fail
+        # not sure how to fix this. Fixture library hasn't been updated in years!
+        # should we move to e.g. mixer?
+        group_query = [{'include': ['dummy'], 'exclude': []}]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -52,20 +52,29 @@ class UserData(DataSet):
         login = 'test_login'
         password = 'test_password'
 
+class GroupData(DataSet):
+    class test_group:
+        user = UserData.test_user
+        name = 'test_group'
+
 
 class SampleData(DataSet):
     class exome_sample:
         user = UserData.test_user
         name = 'Exome sample'
+        group = [GroupData.test_group]
     class exome_subset_sample:
         user = UserData.test_user
         name = 'Exome (subset) sample'
+        group = [GroupData.test_group]
     class gonl_sample:
         user = UserData.test_user
         name = 'GoNL sample'
+        group = [GroupData.test_group]
     class gonl_summary_sample:
         user = UserData.test_user
         name = 'GoNL (summary) sample'
+        group = [GroupData.test_group]
 
 
 class DataSourceData(DataSet):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -504,7 +504,8 @@ class TestTasks(TestCase):
                                         original_filetype=data_source.filetype,
                                         annotated_filetype='vcf',
                                         original_records=records,
-                                        exclude_checksum=checksum)
+                                        exclude_checksum=checksum,
+                                        group_query=[{'include': ['dummy'], 'exclude': []}])
 
             lines = annotated_file.getvalue().split('\n')
             reader = vcf.Reader(lines)

--- a/varda/api/data.py
+++ b/varda/api/data.py
@@ -17,10 +17,11 @@ import cerberus.errors
 from flask import abort, current_app, g, request
 
 from ..models import (Annotation, Coverage, DataSource, Sample, Token, User,
-                      Variation)
+                      Variation, Group)
 from .errors import ValidationError
 from .utils import (annotation_by_uri, coverage_by_uri, data_source_by_uri,
-                    sample_by_uri, token_by_uri, user_by_uri, variation_by_uri)
+                    sample_by_uri, token_by_uri, user_by_uri, variation_by_uri,
+                    group_by_uri)
 
 
 # Todo: Rename cast to coerce.
@@ -63,7 +64,8 @@ def cast(document, schema):
                'token':           _cast_token,
                'user':            _cast_user,
                'variant':         _cast_variant,
-               'variation':       _cast_variation}
+               'variation':       _cast_variation,
+               'group':           _cast_group}
     return_document = {}
     for field, value in document.items():
         definition = schema.get(field)
@@ -171,6 +173,12 @@ def _cast_sample(value, definition):
     elif isinstance(value, basestring):
         return sample_by_uri(current_app, value)
     return value
+    
+def _cast_group(value, definition):
+    if isinstance(value, int):
+        return Group.query.get(value)
+    elif isinstance(value, basestring):
+        return group_by_uri(current_app, value)
 
 
 def _cast_token(value, definition):
@@ -257,6 +265,10 @@ class ApiValidator(Validator):
     def _validate_type_sample(self, field, value):
         if not isinstance(self.document[field], Sample):
             self._error(cerberus.errors.ERROR_BAD_TYPE % (field, 'sample'))
+    
+    def _validate_type_group(self, field, value):
+        if not isinstance(self.document[field], Group):
+            self._error(cerberus.errors.ERROR_BAD_TYPE % (field, 'group'))
 
     def _validate_type_token(self, field, value):
         if not isinstance(self.document[field], Token):

--- a/varda/api/resources/__init__.py
+++ b/varda/api/resources/__init__.py
@@ -15,3 +15,4 @@ from .tokens import TokensResource
 from .users import UsersResource
 from .variants import VariantsResource
 from .variations import VariationsResource
+from .groups import GroupsResource

--- a/varda/api/resources/annotations.py
+++ b/varda/api/resources/annotations.py
@@ -68,7 +68,10 @@ class AnnotationsResource(TaskedResource):
                   'global_frequency': {'type': 'boolean'},
                   'sample_frequency': {'type': 'list',
                                        'maxlength': 30,
-                                       'schema': {'type': 'sample'}}}
+                                       'schema': {'type': 'sample'}},
+                  'group_query': {'type': 'list',
+                                  'maxlength': 10,
+                                  'schema': {'type': 'dict', 'schema': {}}}}
 
     delete_ensure_conditions = [has_role('admin'), owns_annotation]
     delete_ensure_options = {'satisfy': any}
@@ -124,7 +127,7 @@ class AnnotationsResource(TaskedResource):
 
     @classmethod
     def add_view(cls, data_source, name=None, global_frequency=True,
-                 sample_frequency=None):
+                 sample_frequency=None, group_query=None):
         """
         Adds an annotation resource.
 
@@ -145,6 +148,7 @@ class AnnotationsResource(TaskedResource):
         - **name** (`string`)
         - **global_frequency** (`boolean`)
         - **sample_frequency** (`list` of `uri`)
+        - **group_query** (`list` of `dict` of queries on groups)
         """
         # Todo: Check if data source is a VCF file.
         # The `satisfy` keyword argument used here in the `ensure` decorator means
@@ -182,7 +186,8 @@ class AnnotationsResource(TaskedResource):
         db.session.add(annotated_data_source)
         annotation = Annotation(data_source, annotated_data_source,
                                 global_frequency=global_frequency,
-                                sample_frequency=sample_frequency)
+                                sample_frequency=sample_frequency,
+                                group_query=group_query)
         db.session.add(annotation)
         db.session.commit()
         current_app.logger.info('Added data source: %r', annotated_data_source)

--- a/varda/api/resources/annotations.py
+++ b/varda/api/resources/annotations.py
@@ -71,7 +71,7 @@ class AnnotationsResource(TaskedResource):
                                        'schema': {'type': 'sample'}},
                   'group_query': {'type': 'list',
                                   'maxlength': 10,
-                                  'schema': {'type': 'dict', 'schema': {}}}}
+                                  'schema': {'type': 'dict', 'schema': {'allow_unknown': True}}}}
 
     delete_ensure_conditions = [has_role('admin'), owns_annotation]
     delete_ensure_options = {'satisfy': any}

--- a/varda/api/resources/groups.py
+++ b/varda/api/resources/groups.py
@@ -33,7 +33,7 @@ class GroupsResource(ModelResource):
     
     # TODO: add owns_group function to security module
     edit_ensure_conditions = [has_role('admin'), owns_group]
-    edit_ensure_options = {'satisfy' : any}
+    edit_ensure_options = {'satisfy': any}
     edit_schema = {'name': {'type': 'string', 'required': True, 'maxlength': 200}}
     
     # TODO: add owns_group function to security module

--- a/varda/api/resources/groups.py
+++ b/varda/api/resources/groups.py
@@ -1,7 +1,7 @@
 from flask import g, url_for
 
-from ..models import Group
-from ..security import is_user, has_role, true
+from ...models import Group
+from ..security import is_user, has_role, true, owns_group
 from .base import ModelResource
 from .users import UsersResource
 
@@ -29,12 +29,12 @@ class GroupsResource(ModelResource):
     
     add_ensure_conditions = [has_role('admin'), has_role('importer')]
     add_ensure_options = {'satisfy': any}
-    add_schema = {'name': {'type': 'string', 'required' = True, 'maxlength': 200}}
+    add_schema = {'name': {'type': 'string', 'required': True, 'maxlength': 200}}
     
     # TODO: add owns_group function to security module
     edit_ensure_conditions = [has_role('admin'), owns_group]
     edit_ensure_options = {'satisfy' : any}
-    edit_schema = {'name': {'type': 'string', 'required' = True, 'maxlength': 200}}
+    edit_schema = {'name': {'type': 'string', 'required': True, 'maxlength': 200}}
     
     # TODO: add owns_group function to security module
     delete_ensure_conditions = [has_role('admin'), owns_group]

--- a/varda/api/resources/groups.py
+++ b/varda/api/resources/groups.py
@@ -1,0 +1,89 @@
+from flask import g, url_for
+
+from ..models import Group
+from ..security import is_user, has_role, true
+from .base import ModelResource
+from .users import UsersResource
+
+class GroupsResource(ModelResource):
+    """
+    Group resources model user-specified groups (e.g. disease type)
+    """
+        
+    model = Group
+    instance_name = 'group'
+    instance_type = 'group'
+    
+    views = ['list', 'get', 'add', 'edit', 'delete']
+    
+    embeddable = {'user': UsersResource}
+    filterable = {} # empty dict is necessary??
+    orderable = ['name']
+    
+    # only admin should be able to see all groups?
+    list_ensure_conditions = [has_role('admin')]
+    list_ensure_options = {'satisfy': any}
+    
+    get_ensure_conditions = [has_role('admin')]
+    get_ensure_options = {'satisfy': any}
+    
+    add_ensure_conditions = [has_role('admin'), has_role('importer')]
+    add_ensure_options = {'satisfy': any}
+    add_schema = {'name': {'type': 'string', 'required' = True, 'maxlength': 200}}
+    
+    # TODO: add owns_group function to security module
+    edit_ensure_conditions = [has_role('admin')]
+    edit_ensure_options = {'satisfy' : any}
+    edit_schema = {'name': {'type': 'string', 'required' = True, 'maxlength': 200}}
+    
+    # TODO: add owns_group function to security module
+    delete_ensure_conditions = [has_role('admin')]
+    delete_ensure_options = {'satisfy': any}
+    
+    @classmethod
+    def serialize(cls, instance, embed=None):
+        """
+        A group is representend as an object with the following fields:
+        
+        **uri** (`uri`)
+        URI for this resource
+        
+        **name** (`string`)
+        Human readable name for group
+        
+        **added** (`string`)
+        Date and time this group was added
+        
+        **user**(`object`)
+        :ref:`Link <api-links> to a :ref:user
+        """
+        
+        serialization = super(GroupsResource, cls).serialize(instance, embed=embed)
+        serialization.update(name=instance.name,
+                             added=str(instance.added.isoformat()))
+        
+        return serialization
+        
+    @classmethod
+    def list_view(cls, *args, **kwargs):
+        """
+        Returns a colleciton of samples in the `group_collection` field.        
+        """
+        return super(GroupsResource, cls).list_view(*args, **kwargs)
+        
+    @classmethod
+    def get_view(cls, *args, **kwargs):
+        return super(GroupsResource, cls).get_view(*args, **kwargs)
+    
+    @classmethod
+    def add_view(cls, *args, **kwargs):
+        kwargs['user'] = g.user
+        return super(GroupsResource, cls).add_view(*args, **kwargs)
+        
+    @classmethod
+    def edit_view(cls, *args, **kwargs):
+        return super(GroupsResource, cls).edit_view(*args, **kwargs)
+        
+    @classmethod
+    def delete_view(cls, *args, **kwargs):
+        return super(GroupsResource, cls).delete_view(*args, **kwargs)

--- a/varda/api/resources/groups.py
+++ b/varda/api/resources/groups.py
@@ -24,7 +24,7 @@ class GroupsResource(ModelResource):
     list_ensure_conditions = [has_role('admin')]
     list_ensure_options = {'satisfy': any}
     
-    get_ensure_conditions = [has_role('admin')]
+    get_ensure_conditions = [has_role('admin'), owns_group]
     get_ensure_options = {'satisfy': any}
     
     add_ensure_conditions = [has_role('admin'), has_role('importer')]
@@ -32,12 +32,12 @@ class GroupsResource(ModelResource):
     add_schema = {'name': {'type': 'string', 'required' = True, 'maxlength': 200}}
     
     # TODO: add owns_group function to security module
-    edit_ensure_conditions = [has_role('admin')]
+    edit_ensure_conditions = [has_role('admin'), owns_group]
     edit_ensure_options = {'satisfy' : any}
     edit_schema = {'name': {'type': 'string', 'required' = True, 'maxlength': 200}}
     
     # TODO: add owns_group function to security module
-    delete_ensure_conditions = [has_role('admin')]
+    delete_ensure_conditions = [has_role('admin'), owns_group]
     delete_ensure_options = {'satisfy': any}
     
     @classmethod
@@ -67,23 +67,44 @@ class GroupsResource(ModelResource):
     @classmethod
     def list_view(cls, *args, **kwargs):
         """
-        Returns a colleciton of samples in the `group_collection` field.        
+        Returns a colleciton of groups in the `group_collection` field.
+        
+        User must have role `admin` to list all groups        
         """
         return super(GroupsResource, cls).list_view(*args, **kwargs)
         
     @classmethod
     def get_view(cls, *args, **kwargs):
+        """
+        Returns a group 
+        User must have role `admin` or own the group
+        """
         return super(GroupsResource, cls).get_view(*args, **kwargs)
     
     @classmethod
     def add_view(cls, *args, **kwargs):
+        """
+        Adds a group to the collection
+        
+        User must have either role `admin` or `importer`
+        """
         kwargs['user'] = g.user
         return super(GroupsResource, cls).add_view(*args, **kwargs)
         
     @classmethod
     def edit_view(cls, *args, **kwargs):
+        """
+        Edits a group
+        
+        User must have role `admin` or be the owner of the group
+        """
         return super(GroupsResource, cls).edit_view(*args, **kwargs)
         
     @classmethod
     def delete_view(cls, *args, **kwargs):
+        """
+        Deletes a group
+        
+        User most have role `admin` or be the owner of the group
+        """
         return super(GroupsResource, cls).delete_view(*args, **kwargs)

--- a/varda/api/resources/samples.py
+++ b/varda/api/resources/samples.py
@@ -48,7 +48,9 @@ class SamplesResource(ModelResource):
                   'coverage_profile': {'type': 'boolean'},
                   'public': {'type': 'boolean'},
                   'notes': {'type': 'string', 'maxlength': 10000},
-                  'group': {'type': 'group'},
+                  'group': {'type': 'list',
+                            'maxlength': 30,
+                            'schema': {'type': 'group'}},
                   'is_index': {'type': 'boolean'},
                   'parents': {'type': 'sample'}}
 
@@ -60,7 +62,9 @@ class SamplesResource(ModelResource):
                    'coverage_profile': {'type': 'boolean'},
                    'public': {'type': 'boolean'},
                    'notes': {'type': 'string', 'maxlength': 10000},
-                   'group': {'type': 'group'}}
+                   'group': {'type': 'list',
+                             'maxlength': 30,
+                             'schema': {'type': 'group'}}}
 
     delete_ensure_conditions = [has_role('admin'), owns_sample]
     delete_ensure_options = {'satisfy': any}

--- a/varda/api/resources/samples.py
+++ b/varda/api/resources/samples.py
@@ -113,7 +113,7 @@ class SamplesResource(ModelResource):
                              notes=instance.notes,
                              group=instance.group,
                              is_index=instance.is_index,
-                             parents=[x.name for x in instance.parents],
+                             parents=instance.parents,
                              added=str(instance.added.isoformat()))
         return serialization
 

--- a/varda/api/resources/samples.py
+++ b/varda/api/resources/samples.py
@@ -196,4 +196,4 @@ class SamplesResource(ModelResource):
         """
         Todo: documentation, including how/if we cascade.
         """
-        return super(SamplersResource, cls).delete_view(*args, **kwargs)
+        return super(SamplesResource, cls).delete_view(*args, **kwargs)

--- a/varda/api/resources/samples.py
+++ b/varda/api/resources/samples.py
@@ -27,8 +27,7 @@ class SamplesResource(ModelResource):
 
     views = ['list', 'get', 'add', 'edit', 'delete']
 
-    embeddable = {'user': UsersResource,
-                  'group': GroupsResource}
+    embeddable = {'user': UsersResource}
     filterable = {'public': 'boolean',
                   'user': 'user',
                   'is_index': 'boolean',
@@ -113,7 +112,8 @@ class SamplesResource(ModelResource):
                              coverage_profile=instance.coverage_profile,
                              active=instance.active,
                              notes=instance.notes,
-                             added=str(instance.added.isoformat()))
+                             added=str(instance.added.isoformat()),
+                             group=[x.name for x in instance.group])
         return serialization
 
     @classmethod

--- a/varda/api/resources/samples.py
+++ b/varda/api/resources/samples.py
@@ -60,9 +60,7 @@ class SamplesResource(ModelResource):
                    'coverage_profile': {'type': 'boolean'},
                    'public': {'type': 'boolean'},
                    'notes': {'type': 'string', 'maxlength': 10000},
-                   'group': {'type': 'group'},
-                   'is_index': {'type': 'boolean'},
-                   'parents': {'type': 'sample'}}
+                   'group': {'type': 'group'}}
 
     delete_ensure_conditions = [has_role('admin'), owns_sample]
     delete_ensure_options = {'satisfy': any}
@@ -111,9 +109,6 @@ class SamplesResource(ModelResource):
                              coverage_profile=instance.coverage_profile,
                              active=instance.active,
                              notes=instance.notes,
-                             is_index=instance.is_index,
-                             mother=instance.mother,
-                             father=instance.father,
                              added=str(instance.added.isoformat()))
         return serialization
 

--- a/varda/api/resources/samples.py
+++ b/varda/api/resources/samples.py
@@ -13,6 +13,7 @@ from ...models import Sample
 from ..security import is_user, has_role, owns_sample, public_sample, true
 from .base import ModelResource
 from .users import UsersResource
+from .groups import GroupsResource
 
 
 class SamplesResource(ModelResource):
@@ -26,7 +27,8 @@ class SamplesResource(ModelResource):
 
     views = ['list', 'get', 'add', 'edit', 'delete']
 
-    embeddable = {'user': UsersResource}
+    embeddable = {'user': UsersResource,
+                  'group': GroupsResource}
     filterable = {'public': 'boolean',
                   'user': 'user'}
     orderable = ['name', 'pool_size', 'public', 'active', 'added']
@@ -43,7 +45,8 @@ class SamplesResource(ModelResource):
                   'pool_size': {'type': 'integer'},
                   'coverage_profile': {'type': 'boolean'},
                   'public': {'type': 'boolean'},
-                  'notes': {'type': 'string', 'maxlength': 10000}}
+                  'notes': {'type': 'string', 'maxlength': 10000},
+                  'group': {'type': 'group'}}
 
     edit_ensure_conditions = [has_role('admin'), owns_sample]
     edit_ensure_options = {'satisfy': any}
@@ -52,7 +55,8 @@ class SamplesResource(ModelResource):
                    'pool_size': {'type': 'integer'},
                    'coverage_profile': {'type': 'boolean'},
                    'public': {'type': 'boolean'},
-                   'notes': {'type': 'string', 'maxlength': 10000}}
+                   'notes': {'type': 'string', 'maxlength': 10000},
+                   'group': {'type': 'group'}}
 
     delete_ensure_conditions = [has_role('admin'), owns_sample]
     delete_ensure_options = {'satisfy': any}
@@ -89,6 +93,10 @@ class SamplesResource(ModelResource):
         **user** (`object`)
           :ref:`Link <api-links>` to a :ref:`user
           <api-resources-users-instances>` resource (embeddable).
+        
+        **group** (`object`)
+          :ref:`Link <api-links>` to a :ref:`group
+          <api-resources-groups-instances> group (embeddable)
         """
         serialization = super(SamplesResource, cls).serialize(instance, embed=embed)
         serialization.update(name=instance.name,

--- a/varda/api/resources/samples.py
+++ b/varda/api/resources/samples.py
@@ -30,7 +30,9 @@ class SamplesResource(ModelResource):
     embeddable = {'user': UsersResource,
                   'group': GroupsResource}
     filterable = {'public': 'boolean',
-                  'user': 'user'}
+                  'user': 'user',
+                  'is_index': 'boolean',
+                  'group': 'group'}
     orderable = ['name', 'pool_size', 'public', 'active', 'added']
 
     list_ensure_conditions = [has_role('admin'), is_user, true('public')]
@@ -46,7 +48,9 @@ class SamplesResource(ModelResource):
                   'coverage_profile': {'type': 'boolean'},
                   'public': {'type': 'boolean'},
                   'notes': {'type': 'string', 'maxlength': 10000},
-                  'group': {'type': 'group'}}
+                  'group': {'type': 'group'},
+                  'is_index': {'type': 'boolean'},
+                  'parents': {'type': 'sample'}}
 
     edit_ensure_conditions = [has_role('admin'), owns_sample]
     edit_ensure_options = {'satisfy': any}
@@ -56,7 +60,9 @@ class SamplesResource(ModelResource):
                    'coverage_profile': {'type': 'boolean'},
                    'public': {'type': 'boolean'},
                    'notes': {'type': 'string', 'maxlength': 10000},
-                   'group': {'type': 'group'}}
+                   'group': {'type': 'group'},
+                   'is_index': {'type': 'boolean'},
+                   'parents': {'type': 'sample'}}
 
     delete_ensure_conditions = [has_role('admin'), owns_sample]
     delete_ensure_options = {'satisfy': any}
@@ -105,6 +111,9 @@ class SamplesResource(ModelResource):
                              coverage_profile=instance.coverage_profile,
                              active=instance.active,
                              notes=instance.notes,
+                             group=instance.group,
+                             is_index=instance.is_index,
+                             parents=[x.name for x in instance.parents],
                              added=str(instance.added.isoformat()))
         return serialization
 

--- a/varda/api/resources/samples.py
+++ b/varda/api/resources/samples.py
@@ -111,9 +111,8 @@ class SamplesResource(ModelResource):
                              coverage_profile=instance.coverage_profile,
                              active=instance.active,
                              notes=instance.notes,
-                             group=instance.group,
                              is_index=instance.is_index,
-                             parents=instance.parents,
+                             parents=[x.id for x in instance.parents],
                              added=str(instance.added.isoformat()))
         return serialization
 

--- a/varda/api/resources/samples.py
+++ b/varda/api/resources/samples.py
@@ -112,7 +112,8 @@ class SamplesResource(ModelResource):
                              active=instance.active,
                              notes=instance.notes,
                              is_index=instance.is_index,
-                             parents=[x.id for x in instance.parents],
+                             mother=instance.mother,
+                             father=instance.father,
                              added=str(instance.added.isoformat()))
         return serialization
 

--- a/varda/api/security.py
+++ b/varda/api/security.py
@@ -220,6 +220,13 @@ def owns_sample(sample=None, **_):
     currently authenticated user.
     """
     return sample is not None and sample.user is g.user
+    
+def owns_group(group=None, **_):
+    """
+    Condition that is satisfied if the view argument `group` is owned by the
+    currently authenticated user.
+    """
+    return group is not None and group.user is g.user
 
 
 def owns_variation(variation=None, **_):

--- a/varda/api/utils.py
+++ b/varda/api/utils.py
@@ -16,7 +16,7 @@ from werkzeug.exceptions import HTTPException
 from werkzeug.http import parse_range_header
 
 from ..models import (Annotation, Coverage, DataSource, Sample, Token, User,
-                      Variation)
+                      Variation, Group)
 from .errors import ValidationError
 
 
@@ -119,6 +119,16 @@ def sample_by_uri(app, uri):
     except ValueError:
         return None
     return Sample.query.get(args['sample'])
+    
+def group_by_uri(app, uri):
+	"""
+	Get a group from its URI.
+	"""
+	try:
+		args = parse_args(app, 'api.group_get', uri)
+	except ValueError:
+		return None
+	return Group.query.get(args['group'])
 
 
 def token_by_uri(app, uri):

--- a/varda/api/views.py
+++ b/varda/api/views.py
@@ -19,7 +19,8 @@ from .errors import (AcceptError, ActivationFailure, BasicAuthRequiredError,
                      IntegrityError, ValidationError)
 from .resources import (AnnotationsResource, CoveragesResource,
                         DataSourcesResource, SamplesResource, TokensResource,
-                        UsersResource, VariantsResource, VariationsResource)
+                        UsersResource, VariantsResource, VariationsResource,
+                        GroupsResource)
 from .utils import user_by_login, user_by_token
 
 
@@ -215,6 +216,7 @@ coverages_resource = CoveragesResource(api, url_prefix='/coverages')
 data_sources_resource = DataSourcesResource(api, url_prefix='/data_sources')
 annotations_resource = AnnotationsResource(api, url_prefix='/annotations')
 variants_resource = VariantsResource(api, url_prefix='/variants')
+groups_resource = GroupsResource(api, url_prefix='/groups')
 
 
 @api.route('/')
@@ -345,7 +347,8 @@ def root_serialize():
                                  tokens_resource,
                                  users_resource,
                                  variants_resource,
-                                 variations_resource)})
+                                 variations_resource,
+                                 groups_resource)})
     return api
 
 

--- a/varda/models.py
+++ b/varda/models.py
@@ -268,7 +268,7 @@ class Sample(db.Model):
     """
     Sample (of one or more individuals).
     """
-    __tablename__ = 'sample'
+    __tablename__ = 'Sample'
     __table_args__ = {'mysql_engine': 'InnoDB', 'mysql_charset': 'utf8'}
 
     id = db.Column(db.Integer, primary_key=True)
@@ -318,7 +318,7 @@ class Sample(db.Model):
 
     #: Classes `Sample` which are parents to this sample
     parents = db.relationship('Sample')
-    child_id = db.Column(db.Integer, db.ForeignKey('sample.id'))
+    child_id = db.Column(db.Integer, db.ForeignKey('Sample.id'))
 
     def __init__(self, user, name, pool_size=1, coverage_profile=True,
                  public=False, notes=None, group=None):

--- a/varda/models.py
+++ b/varda/models.py
@@ -293,6 +293,34 @@ class Sample(db.Model):
     def __repr__(self):
         return '<Sample %r, pool_size=%r, active=%r, public=%r>' \
             % (self.name, self.pool_size, self.active, self.public)
+            
+class Group(db.Model):
+    """
+    Group (e.g. disease type)
+    """
+    __table_args__ = {"mysql_engine": "InnoDB", "mysql_charset": "utf8"}
+    
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    
+    #: Human readable name
+    name = db.Column(db.String(200))
+    
+    #: date and time of creation
+    added = db.Column(db.DateTime)
+    
+    #: the :class:`User` who created this sample
+    user = db.relationship(User,
+                           backref=db.backref('groups', lazy='dynamic'))
+    
+    def __init__(self, user, name):
+        self.user = user
+        self.name = name
+        self.added = datetime.now()
+        
+    @detached_session_fix
+    def __repr__(self):
+        return '<Group %r>' % (self.name) 
 
 
 class DataSource(db.Model):

--- a/varda/models.py
+++ b/varda/models.py
@@ -313,12 +313,6 @@ class Sample(db.Model):
     group = db.relationship(Group,
                             backref=db.backref('samples', lazy='dynamic'))
 
-    #: Set to true if the sample belongs to a set of samples, and this sample is the index
-    is_index = db.Column(db.Boolean)
-
-    # ids of mother and father
-    mother = db.Column(db.Text)
-    father = db.Column(db.Text)
     def __init__(self, user, name, pool_size=1, coverage_profile=True,
                  public=False, notes=None, group=None):
         
@@ -622,6 +616,10 @@ class Annotation(db.Model):
     sample_frequency = db.relationship(Sample, secondary=sample_frequency,
                                        cascade='all', passive_deletes=True)
 
+    #: Query field for groups. Should be a list of dictionaries, which is serialized by pickle
+    #: e.g. [{'group1': False, 'group2': True}, {'group1': True, 'group2': False}]
+    group_query = db.Column(db.PickleType)
+
     #: The original :class:`DataSource` that is being annotated.
     original_data_source = db.relationship(
         DataSource,
@@ -635,13 +633,14 @@ class Annotation(db.Model):
         backref=db.backref('annotation', uselist=False, lazy='select'))
 
     def __init__(self, original_data_source, annotated_data_source,
-                 global_frequency=True, sample_frequency=None):
+                 global_frequency=True, sample_frequency=None, group_query=None):
         sample_frequency = sample_frequency or []
 
         self.original_data_source = original_data_source
         self.annotated_data_source = annotated_data_source
         self.global_frequency = global_frequency
         self.sample_frequency = sample_frequency
+        self.group_query = group_query
 
     @detached_session_fix
     def __repr__(self):

--- a/varda/models.py
+++ b/varda/models.py
@@ -268,6 +268,7 @@ class Sample(db.Model):
     """
     Sample (of one or more individuals).
     """
+    __tablename__ = 'sample'
     __table_args__ = {'mysql_engine': 'InnoDB', 'mysql_charset': 'utf8'}
 
     id = db.Column(db.Integer, primary_key=True)
@@ -311,6 +312,13 @@ class Sample(db.Model):
     #: A :class:`Group` to which this sample belongs
     group = db.relationship(Group,
                             backref=db.backref('samples', lazy='dynamic'))
+
+    #: Set to true if the sample belongs to a set of samples, and this sample is the index
+    is_index = db.Column(db.Boolean)
+
+    #: Classes `Sample` which are parents to this sample
+    parents = db.relationship('Sample')
+    child_id = db.Column(db.Integer, db.ForeignKey('sample.id'))
 
     def __init__(self, user, name, pool_size=1, coverage_profile=True,
                  public=False, notes=None, group=None):

--- a/varda/models.py
+++ b/varda/models.py
@@ -246,7 +246,7 @@ class Group(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     
     #: Human readable name
-    name = db.Column(db.String(200))
+    name = db.Column(db.String(200), unique=True)
     
     #: date and time of creation
     added = db.Column(db.DateTime)
@@ -316,10 +316,9 @@ class Sample(db.Model):
     #: Set to true if the sample belongs to a set of samples, and this sample is the index
     is_index = db.Column(db.Boolean)
 
-    #: Classes `Sample` which are parents to this sample
-    parents = db.relationship('Sample')
-    child_id = db.Column(db.Integer, db.ForeignKey('sample.id'))
-
+    # ids of mother and father
+    mother = db.Column(db.Text)
+    father = db.Column(db.Text)
     def __init__(self, user, name, pool_size=1, coverage_profile=True,
                  public=False, notes=None, group=None):
         

--- a/varda/models.py
+++ b/varda/models.py
@@ -268,7 +268,7 @@ class Sample(db.Model):
     """
     Sample (of one or more individuals).
     """
-    __tablename__ = 'Sample'
+    __tablename__ = 'sample'
     __table_args__ = {'mysql_engine': 'InnoDB', 'mysql_charset': 'utf8'}
 
     id = db.Column(db.Integer, primary_key=True)
@@ -318,7 +318,7 @@ class Sample(db.Model):
 
     #: Classes `Sample` which are parents to this sample
     parents = db.relationship('Sample')
-    child_id = db.Column(db.Integer, db.ForeignKey('Sample.id'))
+    child_id = db.Column(db.Integer, db.ForeignKey('sample.id'))
 
     def __init__(self, user, name, pool_size=1, coverage_profile=True,
                  public=False, notes=None, group=None):

--- a/varda/models.py
+++ b/varda/models.py
@@ -310,12 +310,12 @@ class Sample(db.Model):
                            backref=db.backref('samples', lazy='dynamic'))
                            
     #: A :class:`Group` to which this sample belongs
-    group = db.relationship(Group,
-                            backref=db.backref('samples', lazy='dynamic'))
+    group = db.relationship(Group, secondary=group_membership,
+                            cascade='all', passive_deletes=True)
 
     def __init__(self, user, name, pool_size=1, coverage_profile=True,
                  public=False, notes=None, group=None):
-        
+
 
         self.user = user
         self.name = name
@@ -591,6 +591,14 @@ sample_frequency = db.Table(
               db.ForeignKey('sample.id', ondelete='CASCADE'),
               nullable=False))
 
+group_membership = db.Table(
+    'group_membership', db.Model.metadata,
+    db.Column('sample_id', db.Integer,
+              db.ForeignKey('sample.id', ondelete='CASCADE'),
+              nullable=False),
+    db.Column('group_id', db.Integer,
+              db.ForeignKey('group.id', ondelete='CASCADE'),
+              nullable=False))
 
 class Annotation(db.Model):
     """

--- a/varda/models.py
+++ b/varda/models.py
@@ -236,6 +236,15 @@ class Token(db.Model):
     def __repr__(self):
         return '<Token %r>' % self.name
 
+group_membership = db.Table(
+    'group_membership', db.Model.metadata,
+    db.Column('sample_id', db.Integer,
+              db.ForeignKey('sample.id', ondelete='CASCADE'),
+              nullable=False),
+    db.Column('group_id', db.Integer,
+              db.ForeignKey('group.id', ondelete='CASCADE'),
+              nullable=False))
+
 class Group(db.Model):
     """
     Group (e.g. disease type)
@@ -591,14 +600,7 @@ sample_frequency = db.Table(
               db.ForeignKey('sample.id', ondelete='CASCADE'),
               nullable=False))
 
-group_membership = db.Table(
-    'group_membership', db.Model.metadata,
-    db.Column('sample_id', db.Integer,
-              db.ForeignKey('sample.id', ondelete='CASCADE'),
-              nullable=False),
-    db.Column('group_id', db.Integer,
-              db.ForeignKey('group.id', ondelete='CASCADE'),
-              nullable=False))
+
 
 class Annotation(db.Model):
     """

--- a/varda/tasks.py
+++ b/varda/tasks.py
@@ -188,10 +188,6 @@ def annotate_variants(original_variants, annotated_variants,
         raise ReadError('Annotated data must be in VCF format')
 
     reader = vcf.Reader(original_variants)
-    groups = Group.query.all()
-    # TODO: THIS RETURNS A BASEQUERY ITEM. MUST CALL .all() AFTERWARDS!!
-    # TODO: Plus, if multiple groups exist with same name this will overwrite.
-    gr_samples = {gr.name: Sample.query.filter_by(group=gr).filter_by(active=True).all() for gr in groups}
 
     # Header line in VCF output for global frequencies.
     if global_frequency:

--- a/varda/tasks.py
+++ b/varda/tasks.py
@@ -345,10 +345,10 @@ def annotate_variants(original_variants, annotated_variants,
             record.add_info(label + '_VF_HET', [vf['heterozygous'] for _, vf in sample_result])
             record.add_info(label + '_VF_HOM', [vf['homozygous'] for _, vf in sample_result])
         for q_name, q_result in query_results.iteritems():
-            record.add_info(q_name + "_VN", [vn for vn, _ in q_result])
-            record.add_info(q_name + "_VF", [sum(vf.values()) for _, vf in q_result])
-            record.add_info(q_name + "_VF_HET", [vf['heterozygous'] for _, vf in q_result])
-            record.add_info(q_name + "_VF_HOM", [vf['homozygous'] for _, vf in q_result])
+            record.add_info(q_name + "_VN", q_result[0])
+            record.add_info(q_name + "_VF", sum(q_result[1].values()))
+            record.add_info(q_name + "_VF_HET", q_result[1]['heterozygous'])
+            record.add_info(q_name + "_VF_HOM", q_result[1]['homozygous'])
 
         writer.write_record(record)
 

--- a/varda/tasks.py
+++ b/varda/tasks.py
@@ -182,6 +182,8 @@ def annotate_variants(original_variants, annotated_variants,
         raise ReadError('Annotated data must be in VCF format')
 
     reader = vcf.Reader(original_variants)
+    groups = Group.query.all()
+    gr_samples = {gr.name: Sample.query.filter_by(group=gr).filter_by(active=True) for gr in groups}
 
     # Header line in VCF output for global frequencies.
     if global_frequency:
@@ -312,15 +314,14 @@ def annotate_variants(original_variants, annotated_variants,
                         chromosome, position, reference, observed,
                         sample=sample, exclude_checksum=exclude_checksum))
 
-            for gr in Group.query.all():
-                gr_samples = Sample.query.filter_by(group=gr).filter_by(active=True)
+            for gr in groups:
                 group_results[gr.name].append(calculate_frequency(
                     chromosome, position, reference, observed,
-                    multi_sample=gr_samples, exclude_checksum=exclude_checksum
+                    multi_sample=gr_samples[gr.name], exclude_checksum=exclude_checksum
                 ))
                 inverse_group_results[gr.name].append(calculate_frequency(
                     chromosome, position, reference, observed,
-                    multi_sample=gr_samples, exclude_checksum=exclude_checksum,
+                    multi_sample=gr_samples[gr.name], exclude_checksum=exclude_checksum,
                     inverse=True
                 ))
 

--- a/varda/tasks.py
+++ b/varda/tasks.py
@@ -183,7 +183,9 @@ def annotate_variants(original_variants, annotated_variants,
 
     reader = vcf.Reader(original_variants)
     groups = Group.query.all()
-    gr_samples = {gr.name: Sample.query.filter_by(group=gr).filter_by(active=True) for gr in groups}
+    # TODO: THIS RETURNS A BASEQUERY ITEM. MUST CALL .all() AFTERWARDS!!
+    # TODO: Plus, if multiple groups exist with same name this will overwrite.
+    gr_samples = {gr.name: Sample.query.filter_by(group=gr).filter_by(active=True).all() for gr in groups}
 
     # Header line in VCF output for global frequencies.
     if global_frequency:

--- a/varda/tasks.py
+++ b/varda/tasks.py
@@ -319,11 +319,11 @@ def annotate_variants(original_variants, annotated_variants,
             for gr in groups:
                 group_results[gr.name].append(calculate_frequency(
                     chromosome, position, reference, observed,
-                    multi_sample=gr_samples[gr.name], exclude_checksum=exclude_checksum
+                    group=gr, exclude_checksum=exclude_checksum
                 ))
                 inverse_group_results[gr.name].append(calculate_frequency(
                     chromosome, position, reference, observed,
-                    multi_sample=gr_samples[gr.name], exclude_checksum=exclude_checksum,
+                    group=gr, exclude_checksum=exclude_checksum,
                     inverse=True
                 ))
 
@@ -593,7 +593,7 @@ def annotate_regions(original_regions, annotated_variants,
                 vn, vf = calculate_frequency(
                     observation.chromosome, observation.position,
                     observation.reference, observation.observed,
-                    multi_sample=gr_samples[gr.name], exclude_checksum=exclude_checksum
+                    group=gr, exclude_checksum=exclude_checksum
                 )
                 fields.extend([vn, sum(vf.values()), vf['heterozygous'],
                                vf['homozygous']])
@@ -602,7 +602,7 @@ def annotate_regions(original_regions, annotated_variants,
                 vn, vf = calculate_frequency(
                     observation.chromosome, observation.position,
                     observation.reference, observation.observed,
-                    exclude_checksum=exclude_checksum, multi_sample=gr_samples[igr.name],
+                    exclude_checksum=exclude_checksum, group=igr,
                     inverse=True
                 )
                 fields.extend([vn, sum(vf.values()), vf['heterozygous'],

--- a/varda/tasks.py
+++ b/varda/tasks.py
@@ -232,7 +232,7 @@ def annotate_variants(original_variants, annotated_variants,
             'homozygous.'
             % sample.name)
 
-    for gr in Group.query():
+    for gr in Group.query.all():
         reader.infos[gr.name + "_VN"] = VcfInfo(
             gr.name + "_VN", vcf_field_counts['A'], 'Integer',
             "Number of individuals having this region covered"
@@ -291,8 +291,8 @@ def annotate_variants(original_variants, annotated_variants,
 
         global_result = []
         sample_results = [[] for _ in sample_frequency]
-        group_results = {gr.name: [] for gr in Group.query()}
-        inverse_group_results = {gr.name: [] for gr in Group.query()}
+        group_results = {gr.name: [] for gr in Group.query.all()}
+        inverse_group_results = {gr.name: [] for gr in Group.query.all()}
         for index, allele in enumerate(record.ALT):
             try:
                 chromosome, position, reference, observed = normalize_variant(
@@ -312,17 +312,17 @@ def annotate_variants(original_variants, annotated_variants,
                         chromosome, position, reference, observed,
                         sample=sample, exclude_checksum=exclude_checksum))
 
-            for gr in Group.query():
-                gr_samples = Sample.query().filter_by(group=gr).filter_by(active=True)
-                group_results[gr.name] = calculate_frequency(
+            for gr in Group.query.all():
+                gr_samples = Sample.query.filter_by(group=gr).filter_by(active=True)
+                group_results[gr.name].append(calculate_frequency(
                     chromosome, position, reference, observed,
                     multi_sample=gr_samples, exclude_checksum=exclude_checksum
-                )
-                inverse_group_results[gr.name] = calculate_frequency(
+                ))
+                inverse_group_results[gr.name].append(calculate_frequency(
                     chromosome, position, reference, observed,
                     multi_sample=gr_samples, exclude_checksum=exclude_checksum,
                     inverse=True
-                )
+                ))
 
         if global_frequency:
             record.add_info('GLOBAL_VN', [vn for vn, _ in global_result])

--- a/varda/tasks.py
+++ b/varda/tasks.py
@@ -330,7 +330,10 @@ def annotate_variants(original_variants, annotated_variants,
                     for zygosity in (None, 'homozygous', 'heterozygous'):
                         vf[zygosity] += [i[zygosity]]
                 for zygo in vf.keys():
-                    vf[zygo] = sum(vf[zygo])/len(vf[zygo])
+                    if len(vf[zygo]) > 0:
+                        vf[zygo] = sum(vf[zygo])/len(vf[zygo])
+                    else:
+                        vf[zygo] = 0
                 query_results[q_name] = (vn, vf)
 
 

--- a/varda/utils.py
+++ b/varda/utils.py
@@ -537,7 +537,7 @@ def get_observations_and_coverage(chromosome, position, reference, observed,
             coverage = sample.pool_size
 
     elif group:
-        samples = Sample.query().filter_by(group=group, active=True, coverage_profile=True)
+        samples = Sample.query.filter_by(group=group).filter_by(active=True).all()
         observations = collections.Counter(dict(
             db.session.query(Observation.zygosity,
                              func.sum(Observation.support)).

--- a/varda/utils.py
+++ b/varda/utils.py
@@ -538,7 +538,7 @@ def get_observations_and_coverage(chromosome, position, reference, observed,
             coverage = sample.pool_size
 
     elif group:
-        samples = Sample.query.filter_by(group=group).filter_by(active=True).all()
+        samples = [x for x in Sample.query.filter_by(active=True).all() if group in x.group]
 
         if len(samples) == 0:
             return None, 0

--- a/varda/utils.py
+++ b/varda/utils.py
@@ -539,6 +539,10 @@ def get_observations_and_coverage(chromosome, position, reference, observed,
 
     elif group:
         samples = Sample.query.filter_by(group=group).filter_by(active=True).all()
+
+        if len(samples) == 0:
+            return None, 0
+
         observations = collections.Counter(dict(
             db.session.query(Observation.zygosity,
                              func.sum(Observation.support)).

--- a/varda/utils.py
+++ b/varda/utils.py
@@ -14,6 +14,7 @@ from __future__ import division
 import collections
 import hashlib
 import itertools
+import json
 
 from flask import current_app
 from sqlalchemy.sql import func
@@ -474,7 +475,7 @@ def calculate_frequency(chromosome, position, reference, observed,
 
     # Todo: Use constant definition for zygosity, probably shared with the
     #     one used in the models.
-    if not coverage:
+    if not coverage or not observations:
         return 0, {zygosity: 0
                    for zygosity in (None, 'homozygous', 'heterozygous')}
 

--- a/varda/utils.py
+++ b/varda/utils.py
@@ -524,6 +524,7 @@ def get_observations_and_coverage(chromosome, position, reference, observed,
             join(Variation).
             join(Sample).
             filter(Sample.id.in_([x.id for x in samples])).
+            filter_by(active=True, coverage_profile=True).
             join(DataSource).
             filter(DataSource.checksum != exclude_checksum).
             group_by(Observation.zygosity)))


### PR DESCRIPTION
This branch adds group functionality. There is a new database model called `Group`. Samples can have one or multiple associated `Group` objects. Furthermore, complex querying is possible on (combinations) of groups. E.g. a group query has the form `[{'include': [a,b], 'exclude': [c,d]}, {'include': [e,f], 'exclude': [g,h]}, {...}]`. Currently a maximum of 10 such queries is supported - mostly due to performance reasons. (I don't imagine much of a use case for more than 10 queries).  
