### PR TITLE
Adding group resource, model, group interface and tests

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -52,20 +52,29 @@ class UserData(DataSet):
         login = 'test_login'
         password = 'test_password'
 
+class GroupData(DataSet):
+    class test_group:
+        user = UserData.test_user
+        name = 'test_group'
+
 
 class SampleData(DataSet):
     class exome_sample:
         user = UserData.test_user
         name = 'Exome sample'
+        group = [GroupData.test_group]
     class exome_subset_sample:
         user = UserData.test_user
         name = 'Exome (subset) sample'
+        group = [GroupData.test_group]
     class gonl_sample:
         user = UserData.test_user
         name = 'GoNL sample'
+        group = [GroupData.test_group]
     class gonl_summary_sample:
         user = UserData.test_user
         name = 'GoNL (summary) sample'
+        group = [GroupData.test_group]
 
 
 class DataSourceData(DataSet):
@@ -142,3 +151,8 @@ class AnnotationData(DataSet):
     class exome_annotation:
         original_data_source = DataSourceData.exome_variation
         annotated_data_source = DataSourceData.empty_variation
+
+        # fixture doesn't take PickleType! So this will fail
+        # not sure how to fix this. Fixture library hasn't been updated in years!
+        # should we move to e.g. mixer?
+        group_query = [{'include': ['dummy'], 'exclude': []}]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -504,7 +504,8 @@ class TestTasks(TestCase):
                                         original_filetype=data_source.filetype,
                                         annotated_filetype='vcf',
                                         original_records=records,
-                                        exclude_checksum=checksum)
+                                        exclude_checksum=checksum,
+                                        group_query=[{'include': ['dummy'], 'exclude': []}])
 
             lines = annotated_file.getvalue().split('\n')
             reader = vcf.Reader(lines)

--- a/varda/api/data.py
+++ b/varda/api/data.py
@@ -17,10 +17,11 @@ import cerberus.errors
 from flask import abort, current_app, g, request
 
 from ..models import (Annotation, Coverage, DataSource, Sample, Token, User,
-                      Variation)
+                      Variation, Group)
 from .errors import ValidationError
 from .utils import (annotation_by_uri, coverage_by_uri, data_source_by_uri,
-                    sample_by_uri, token_by_uri, user_by_uri, variation_by_uri)
+                    sample_by_uri, token_by_uri, user_by_uri, variation_by_uri,
+                    group_by_uri)
 
 
 # Todo: Rename cast to coerce.
@@ -63,7 +64,8 @@ def cast(document, schema):
                'token':           _cast_token,
                'user':            _cast_user,
                'variant':         _cast_variant,
-               'variation':       _cast_variation}
+               'variation':       _cast_variation,
+               'group':           _cast_group}
     return_document = {}
     for field, value in document.items():
         definition = schema.get(field)
@@ -171,6 +173,12 @@ def _cast_sample(value, definition):
     elif isinstance(value, basestring):
         return sample_by_uri(current_app, value)
     return value
+    
+def _cast_group(value, definition):
+    if isinstance(value, int):
+        return Group.query.get(value)
+    elif isinstance(value, basestring):
+        return group_by_uri(current_app, value)
 
 
 def _cast_token(value, definition):
@@ -257,6 +265,10 @@ class ApiValidator(Validator):
     def _validate_type_sample(self, field, value):
         if not isinstance(self.document[field], Sample):
             self._error(cerberus.errors.ERROR_BAD_TYPE % (field, 'sample'))
+    
+    def _validate_type_group(self, field, value):
+        if not isinstance(self.document[field], Group):
+            self._error(cerberus.errors.ERROR_BAD_TYPE % (field, 'group'))
 
     def _validate_type_token(self, field, value):
         if not isinstance(self.document[field], Token):

--- a/varda/api/resources/__init__.py
+++ b/varda/api/resources/__init__.py
@@ -15,3 +15,4 @@ from .tokens import TokensResource
 from .users import UsersResource
 from .variants import VariantsResource
 from .variations import VariationsResource
+from .groups import GroupsResource

--- a/varda/api/resources/groups.py
+++ b/varda/api/resources/groups.py
@@ -1,0 +1,110 @@
+from flask import g, url_for
+
+from ...models import Group
+from ..security import is_user, has_role, true, owns_group
+from .base import ModelResource
+from .users import UsersResource
+
+class GroupsResource(ModelResource):
+    """
+    Group resources model user-specified groups (e.g. disease type)
+    """
+        
+    model = Group
+    instance_name = 'group'
+    instance_type = 'group'
+    
+    views = ['list', 'get', 'add', 'edit', 'delete']
+    
+    embeddable = {'user': UsersResource}
+    filterable = {} # empty dict is necessary??
+    orderable = ['name']
+    
+    # only admin should be able to see all groups?
+    list_ensure_conditions = [has_role('admin')]
+    list_ensure_options = {'satisfy': any}
+    
+    get_ensure_conditions = [has_role('admin'), owns_group]
+    get_ensure_options = {'satisfy': any}
+    
+    add_ensure_conditions = [has_role('admin'), has_role('importer')]
+    add_ensure_options = {'satisfy': any}
+    add_schema = {'name': {'type': 'string', 'required': True, 'maxlength': 200}}
+    
+    # TODO: add owns_group function to security module
+    edit_ensure_conditions = [has_role('admin'), owns_group]
+    edit_ensure_options = {'satisfy': any}
+    edit_schema = {'name': {'type': 'string', 'required': True, 'maxlength': 200}}
+    
+    # TODO: add owns_group function to security module
+    delete_ensure_conditions = [has_role('admin'), owns_group]
+    delete_ensure_options = {'satisfy': any}
+    
+    @classmethod
+    def serialize(cls, instance, embed=None):
+        """
+        A group is representend as an object with the following fields:
+        
+        **uri** (`uri`)
+        URI for this resource
+        
+        **name** (`string`)
+        Human readable name for group
+        
+        **added** (`string`)
+        Date and time this group was added
+        
+        **user**(`object`)
+        :ref:`Link <api-links> to a :ref:user
+        """
+        
+        serialization = super(GroupsResource, cls).serialize(instance, embed=embed)
+        serialization.update(name=instance.name,
+                             added=str(instance.added.isoformat()))
+        
+        return serialization
+        
+    @classmethod
+    def list_view(cls, *args, **kwargs):
+        """
+        Returns a colleciton of groups in the `group_collection` field.
+        
+        User must have role `admin` to list all groups        
+        """
+        return super(GroupsResource, cls).list_view(*args, **kwargs)
+        
+    @classmethod
+    def get_view(cls, *args, **kwargs):
+        """
+        Returns a group 
+        User must have role `admin` or own the group
+        """
+        return super(GroupsResource, cls).get_view(*args, **kwargs)
+    
+    @classmethod
+    def add_view(cls, *args, **kwargs):
+        """
+        Adds a group to the collection
+        
+        User must have either role `admin` or `importer`
+        """
+        kwargs['user'] = g.user
+        return super(GroupsResource, cls).add_view(*args, **kwargs)
+        
+    @classmethod
+    def edit_view(cls, *args, **kwargs):
+        """
+        Edits a group
+        
+        User must have role `admin` or be the owner of the group
+        """
+        return super(GroupsResource, cls).edit_view(*args, **kwargs)
+        
+    @classmethod
+    def delete_view(cls, *args, **kwargs):
+        """
+        Deletes a group
+        
+        User most have role `admin` or be the owner of the group
+        """
+        return super(GroupsResource, cls).delete_view(*args, **kwargs)

--- a/varda/api/security.py
+++ b/varda/api/security.py
@@ -220,6 +220,13 @@ def owns_sample(sample=None, **_):
     currently authenticated user.
     """
     return sample is not None and sample.user is g.user
+    
+def owns_group(group=None, **_):
+    """
+    Condition that is satisfied if the view argument `group` is owned by the
+    currently authenticated user.
+    """
+    return group is not None and group.user is g.user
 
 
 def owns_variation(variation=None, **_):

--- a/varda/api/utils.py
+++ b/varda/api/utils.py
@@ -16,7 +16,7 @@ from werkzeug.exceptions import HTTPException
 from werkzeug.http import parse_range_header
 
 from ..models import (Annotation, Coverage, DataSource, Sample, Token, User,
-                      Variation)
+                      Variation, Group)
 from .errors import ValidationError
 
 
@@ -119,6 +119,16 @@ def sample_by_uri(app, uri):
     except ValueError:
         return None
     return Sample.query.get(args['sample'])
+    
+def group_by_uri(app, uri):
+	"""
+	Get a group from its URI.
+	"""
+	try:
+		args = parse_args(app, 'api.group_get', uri)
+	except ValueError:
+		return None
+	return Group.query.get(args['group'])
 
 
 def token_by_uri(app, uri):

--- a/varda/api/views.py
+++ b/varda/api/views.py
@@ -19,7 +19,8 @@ from .errors import (AcceptError, ActivationFailure, BasicAuthRequiredError,
                      IntegrityError, ValidationError)
 from .resources import (AnnotationsResource, CoveragesResource,
                         DataSourcesResource, SamplesResource, TokensResource,
-                        UsersResource, VariantsResource, VariationsResource)
+                        UsersResource, VariantsResource, VariationsResource,
+                        GroupsResource)
 from .utils import user_by_login, user_by_token
 
 
@@ -215,6 +216,7 @@ coverages_resource = CoveragesResource(api, url_prefix='/coverages')
 data_sources_resource = DataSourcesResource(api, url_prefix='/data_sources')
 annotations_resource = AnnotationsResource(api, url_prefix='/annotations')
 variants_resource = VariantsResource(api, url_prefix='/variants')
+groups_resource = GroupsResource(api, url_prefix='/groups')
 
 
 @api.route('/')
@@ -345,7 +347,8 @@ def root_serialize():
                                  tokens_resource,
                                  users_resource,
                                  variants_resource,
-                                 variations_resource)})
+                                 variations_resource,
+                                 groups_resource)})
     return api
 
 

--- a/varda/models.py
+++ b/varda/models.py
@@ -248,15 +248,54 @@ class Token(db.Model):
     def __repr__(self):
         return '<Token %r>' % self.name
 
+group_membership = db.Table(
+    'group_membership', db.Model.metadata,
+    db.Column('sample_id', db.Integer,
+              db.ForeignKey('sample.id', ondelete='CASCADE'),
+              nullable=False),
+    db.Column('group_id', db.Integer,
+              db.ForeignKey('group.id', ondelete='CASCADE'),
+              nullable=False))
+
+class Group(db.Model):
+    """
+    Group (e.g. disease type)
+    """
+    __table_args__ = {"mysql_engine": "InnoDB", "mysql_charset": "utf8"}
+    
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    
+    #: Human readable name
+    name = db.Column(db.String(200), unique=True)
+    
+    #: date and time of creation
+    added = db.Column(db.DateTime)
+    
+    #: the :class:`User` who created this sample
+    user = db.relationship(User,
+                           backref=db.backref('groups', lazy='dynamic'))
+    
+    def __init__(self, user, name):
+        self.user = user
+        self.name = name
+        self.added = datetime.now()
+        
+    @detached_session_fix
+    def __repr__(self):
+        return '<Group %r>' % (self.name) 
 
 class Sample(db.Model):
     """
     Sample (of one or more individuals).
     """
+    __tablename__ = 'sample'
     __table_args__ = {'mysql_engine': 'InnoDB', 'mysql_charset': 'utf8'}
 
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    group_id = db.Column(db.Integer, db.ForeignKey('group.id'),
+                               nullable=True)
 
     #: Human-readable name.
     name = db.Column(db.String(200))
@@ -290,9 +329,15 @@ class Sample(db.Model):
     #: The :class:`User` owning this sample.
     user = db.relationship(User,
                            backref=db.backref('samples', lazy='dynamic'))
+                           
+    #: A :class:`Group` to which this sample belongs
+    group = db.relationship(Group, secondary=group_membership,
+                            cascade='all', passive_deletes=True)
 
     def __init__(self, user, name, pool_size=1, coverage_profile=True,
-                 public=False, notes=None):
+                 public=False, notes=None, group=None):
+
+
         self.user = user
         self.name = name
         self.pool_size = pool_size
@@ -300,12 +345,13 @@ class Sample(db.Model):
         self.coverage_profile = coverage_profile
         self.public = public
         self.notes = notes
+        self.group = group
 
     @detached_session_fix
     def __repr__(self):
-        return '<Sample %r, pool_size=%r, active=%r, public=%r>' \
-            % (self.name, self.pool_size, self.active, self.public)
-
+        return '<Sample %r, pool_size=%r, active=%r, public=%r, group=%r>' \
+            % (self.name, self.pool_size, self.active, self.public, self.group)
+            
 
 class DataSource(db.Model):
     """
@@ -567,6 +613,7 @@ sample_frequency = db.Table(
               nullable=False))
 
 
+
 class Annotation(db.Model):
     """
     Annotation of a data source.
@@ -591,6 +638,10 @@ class Annotation(db.Model):
     sample_frequency = db.relationship(Sample, secondary=sample_frequency,
                                        cascade='all', passive_deletes=True)
 
+    #: Query field for groups. Should be a list of dictionaries, which is serialized by pickle
+    #: e.g. [{'group1': False, 'group2': True}, {'group1': True, 'group2': False}]
+    group_query = db.Column(db.PickleType)
+
     #: The original :class:`DataSource` that is being annotated.
     original_data_source = db.relationship(
         DataSource,
@@ -604,13 +655,14 @@ class Annotation(db.Model):
         backref=db.backref('annotation', uselist=False, lazy='select'))
 
     def __init__(self, original_data_source, annotated_data_source,
-                 global_frequency=True, sample_frequency=None):
+                 global_frequency=True, sample_frequency=None, group_query=None):
         sample_frequency = sample_frequency or []
 
         self.original_data_source = original_data_source
         self.annotated_data_source = annotated_data_source
         self.global_frequency = global_frequency
         self.sample_frequency = sample_frequency
+        self.group_query = group_query
 
     @detached_session_fix
     def __repr__(self):

--- a/varda/utils.py
+++ b/varda/utils.py
@@ -14,12 +14,13 @@ from __future__ import division
 import collections
 import hashlib
 import itertools
+import json
 
 from flask import current_app
 from sqlalchemy.sql import func
 
 from . import db, genome
-from .models import Coverage, DataSource, Observation, Region, Sample, Variation
+from .models import Coverage, DataSource, Observation, Region, Sample, Variation, Group
 from .region_binning import all_bins
 
 
@@ -350,7 +351,8 @@ def read_genotype(call, prefer_likelihoods=False):
 
 
 def calculate_frequency(chromosome, position, reference, observed,
-                        sample=None, exclude_checksum=None):
+                        sample=None, exclude_checksum=None,
+                        group=None, inverse=False):
     """
     Calculate frequency for a variant.
 
@@ -372,32 +374,95 @@ def calculate_frequency(chromosome, position, reference, observed,
     end_position = position + max(1, len(reference)) - 1
     bins = all_bins(position, end_position)
 
-    if sample:
-        observations = collections.Counter(dict(
-            db.session.query(Observation.zygosity,
-                          func.sum(Observation.support)).
-            filter(Observation.bin.in_(bins)).
-            filter_by(chromosome=chromosome,
-                      position=position,
-                      reference=reference,
-                      observed=observed).
-            join(Variation).
-            filter_by(sample=sample).
-            join(DataSource).
-            filter(DataSource.checksum != exclude_checksum).
-            group_by(Observation.zygosity)))
+    if sample and not inverse:
+        observations, coverage = get_observations_and_coverage(
+            chromosome=chromosome,
+            position=position,
+            reference=reference,
+            observed=observed,
+            bins=bins,
+            end_position=end_position,
+            global_freq=False,
+            exclude_checksum=exclude_checksum,
+            sample=sample
+        )
 
-        if sample.coverage_profile:
-            coverage = Region.query.join(Coverage).filter(
-                Region.chromosome == chromosome,
-                Region.begin <= position,
-                Region.end >= end_position,
-                Region.bin.in_(bins),
-                Coverage.sample == sample).count()
-        else:
-            coverage = sample.pool_size
+    elif sample and inverse:
+        global_obs, global_cov = get_observations_and_coverage(
+            chromosome=chromosome,
+            position=position,
+            reference=reference,
+            observed=observed,
+            bins=bins,
+            end_position=end_position,
+            global_freq=True,
+            exclude_checksum=exclude_checksum
+        )
+
+        sample_obs, sample_cov = get_observations_and_coverage(
+            chromosome=chromosome,
+            position=position,
+            reference=reference,
+            observed=observed,
+            bins=bins,
+            end_position=end_position,
+            global_freq=False,
+            exclude_checksum=exclude_checksum,
+            sample=sample
+        )
+
+        observations = global_obs.subtract(sample_obs)
+        coverage = global_cov - sample_cov
+
+    elif group and not sample and not inverse:
+        observations, coverage = get_observations_and_coverage(
+            chromosome=chromosome,
+            position=position,
+            reference=reference,
+            observed=observed,
+            bins=bins,
+            end_position=end_position,
+            exclude_checksum=exclude_checksum,
+            global_freq=False,
+            group=group
+        )
+
+    elif group and inverse and not sample:
+        global_obs, global_cov = get_observations_and_coverage(
+            chromosome=chromosome,
+            position=position,
+            reference=reference,
+            observed=observed,
+            bins=bins,
+            end_position=end_position,
+            global_freq=True,
+            exclude_checksum=exclude_checksum
+        )
+        sample_obs, sample_cov = get_observations_and_coverage(
+            chromosome=chromosome,
+            position=position,
+            reference=reference,
+            observed=observed,
+            bins=bins,
+            end_position=end_position,
+            exclude_checksum=exclude_checksum,
+            global_freq=False,
+            group=group
+        )
+        observations = global_obs.subtract(sample_obs)
+        coverage = global_cov - sample_cov
 
     else:
+        observations, coverage = get_observations_and_coverage(
+            chromosome=chromosome,
+            position=position,
+            reference=reference,
+            observed=observed,
+            bins=bins,
+            end_position=end_position,
+            global_freq=True,
+            exclude_checksum=exclude_checksum
+        )
         # Frequency over entire database, except:
         #  - observations imported from data source with `exclude_checksum`
         #  - samples without coverage profile
@@ -407,6 +472,24 @@ def calculate_frequency(chromosome, position, reference, observed,
         # Todo: More seriously, also the corresponding region should be
         #     excluded. I see no real other way to do this than by excluding
         #     the entire sample.
+
+    # Todo: Use constant definition for zygosity, probably shared with the
+    #     one used in the models.
+    if not coverage or not observations:
+        return 0, {zygosity: 0
+                   for zygosity in (None, 'homozygous', 'heterozygous')}
+
+    frequency = {zygosity: observations[zygosity] / coverage
+                 for zygosity in (None, 'homozygous', 'heterozygous')}
+
+    return coverage, frequency
+
+def get_observations_and_coverage(chromosome, position, reference, observed,
+                                  bins, end_position,
+                                  global_freq=True,
+                                  exclude_checksum=None, sample=None, group=None):
+
+    if global_freq:
         observations = collections.Counter(dict(
             db.session.query(Observation.zygosity,
                           func.sum(Observation.support)).
@@ -430,13 +513,58 @@ def calculate_frequency(chromosome, position, reference, observed,
             Region.bin.in_(bins)).join(Sample).filter_by(
             active=True).count()
 
-    # Todo: Use constant definition for zygosity, probably shared with the
-    #     one used in the models.
-    if not coverage:
-        return 0, {zygosity: 0
-                   for zygosity in (None, 'homozygous', 'heterozygous')}
+    elif sample:
+        observations = collections.Counter(dict(
+            db.session.query(Observation.zygosity,
+                          func.sum(Observation.support)).
+            filter(Observation.bin.in_(bins)).
+            filter_by(chromosome=chromosome,
+                      position=position,
+                      reference=reference,
+                      observed=observed).
+            join(Variation).
+            filter_by(sample=sample).
+            join(DataSource).
+            filter(DataSource.checksum != exclude_checksum).
+            group_by(Observation.zygosity)))
+        if sample.coverage_profile:
+            coverage = Region.query.join(Coverage).filter(
+                Region.chromosome == chromosome,
+                Region.begin <= position,
+                Region.end >= end_position,
+                Region.bin.in_(bins),
+                Coverage.sample == sample).count()
+        else:
+            coverage = sample.pool_size
 
-    frequency = {zygosity: observations[zygosity] / coverage
-                 for zygosity in (None, 'homozygous', 'heterozygous')}
+    elif group:
+        samples = [x for x in Sample.query.filter_by(active=True).all() if group in x.group]
 
-    return coverage, frequency
+        if len(samples) == 0:
+            return None, 0
+
+        observations = collections.Counter(dict(
+            db.session.query(Observation.zygosity,
+                             func.sum(Observation.support)).
+            filter(Observation.bin.in_(bins)).
+            filter_by(chromosome=chromosome,
+                      position=position,
+                      reference=reference,
+                      observed=observed).
+            join(Variation).
+            join(Sample).
+            filter(Sample.id.in_([x.id for x in samples])).
+            join(DataSource).
+            filter(DataSource.checksum != exclude_checksum).
+            group_by(Observation.zygosity)
+        ))
+        coverage = Region.query.join(Coverage).filter(
+            Region.chromosome == chromosome,
+            Region.begin <= position,
+            Region.end >= end_position,
+            Region.bin.in_(bins)).join(Sample).filter(Sample.id.in_([x.id for x in samples])).count()
+
+    else:
+        raise ValueError
+
+    return observations, coverage


### PR DESCRIPTION
This branch adds group functionality. There is a new database model called Group. Samples can have one or multiple associated Group objects. Furthermore, complex querying is possible on (combinations) of groups. E.g. a group query has the form `[{'include': [a,b], 'exclude': [c,d]}, {'include': [e,f], 'exclude': [g,h]}, {...}]`. Currently a maximum of 10 such queries is supported - mostly due to performance reasons. (I don't imagine much of a use case for more than 10 queries). 
