### PR TITLE
Remove NumPy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ nose==1.3.0
 psycopg2==2.5.3
 py-bcrypt==0.4
 Sphinx==1.2.2
-numpy==1.8.0
 pyfaidx==0.4.1
 sphinxcontrib-httpdomain==1.2.0
 Cerberus==0.1.0


### PR DESCRIPTION
NumPy was required by pyfasta, but we switched to pyfaidx.
