### PR TITLE
Fix race conditions using genome in Celery workers

### DIFF
--- a/varda/worker.py
+++ b/varda/worker.py
@@ -7,8 +7,22 @@ Helper module for celery to run a worker.
 """
 
 
-from . import celery, create_app
+from celery.signals import worker_process_init
+
+from . import create_app, genome
+
+
+@worker_process_init.connect
+def init_genome(**kwargs):
+    # Duplicate the open file object of the reference genome. This is needed
+    # because file descriptors are inherited after fork, and thus shared
+    # between worker processes, causing race conditions with seek and read.
+    f = genome.faidx.file
+    genome.faidx.file = open(f.name, f.mode)
 
 
 # Todo: Should we make it possible to use create_reverse_proxied_app here?
 create_app().app_context().push()
+
+
+from . import celery  # noqa


### PR DESCRIPTION
When `REFERENCE_MISMATCH_ABORT=True`, using the Celery prefork
worker pool with concurrency at least 2, importing many VCF files
at the same time would yield errors like the following:

```
TaskError: ('invalid_observations', 'Sequence "G" does not match reference genome on "chrX" at position 74546623')
```

The reason for this was that file descriptors are inherited after
fork, and thus shared between worker processes. This caused race
conditions with seek and read operations on the genome FASTA file
because it was opened before forking.

The fix is to duplicate the open file object of the FASTA file
after forking.
